### PR TITLE
Add concurrency settings to secret scan workflow

### DIFF
--- a/.github/workflows/security-secret-scan.yml
+++ b/.github/workflows/security-secret-scan.yml
@@ -5,12 +5,17 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read   # minimal, no write access
 
 jobs:
   secret-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request updates the `security-secret-scan.yml` GitHub Actions workflow to improve CI efficiency and reliability. The most important changes are:

Workflow concurrency improvements:
* Added a `concurrency` group to ensure that only one instance of the workflow runs per branch at a time, and cancels any in-progress runs if a new one is triggered.

Workflow reliability:
* Set a `timeout-minutes` value of 20 for the `secret-scan` job to prevent jobs from running indefinitely.